### PR TITLE
better jsonapi compliance

### DIFF
--- a/ignite-gpt-openapi/paths.yaml
+++ b/ignite-gpt-openapi/paths.yaml
@@ -3,38 +3,32 @@
     summary: Get trees
     operationId: getTrees
     parameters:
-      - name: owner
+      - name: page[number]
         in: query
-        required: false
-        schema:
-          type: string
-      - name: forks
-        in: query
-        required: false
+        description: Page number for pagination
         schema:
           type: integer
-      - name: createdAt
+      - name: page[size]
         in: query
-        required: false
-        schema:
-          type: string
-          format: date-time
-      - name: updatedAt
-        in: query
-        required: false
-        schema:
-          type: string
-          format: date-time
-      - name: page
-        in: query
-        required: false
+        description: Number of records per page for pagination
         schema:
           type: integer
-      - name: pageSize
+      - name: sort
         in: query
-        required: false
+        description: Comma-separated field names to sort by. Use -<fieldname> for descending order.
         schema:
-          type: integer
+          type: string
+      - name: filter
+        in: query
+        description: Field to filter by, in the format filter[<fieldname>][<operator>]=<value>. Operators can be eq (equals), gt (greater than), lt (less than), gte (greater than or equals), lte (less than or equals), ne (not equals).
+        style: deepObject
+        explode: true
+        schema:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties:
+              type: string
     responses:
       '200':
         description: A list of trees
@@ -153,40 +147,32 @@
         required: true
         schema:
           type: string
-      - name: parent
+      - name: page[number]
         in: query
-        required: false
-        schema:
-          type: string
-      - name: role
-        in: query
-        required: false
-        schema:
-          type: string
-      - name: createdAt
-        in: query
-        required: false
-        schema:
-          type: string
-          format: date-time
-      - name: updatedAt
-        in: query
-        required: false
-        schema:
-          type: string
-          format: date-time
-      - name: page
-        in: query
-        required: false
+        description: Page number for pagination
         schema:
           type: integer
-          format: int64
-      - name: pageSize
+      - name: page[size]
         in: query
-        required: false
+        description: Number of records per page for pagination
         schema:
           type: integer
-          format: int64
+      - name: sort
+        in: query
+        description: Comma-separated field names to sort by. Use -<fieldname> for descending order.
+        schema:
+          type: string
+      - name: filter
+        in: query
+        description: Field to filter by, in the format filter[<fieldname>][<operator>]=<value>. Operators can be eq (equals), gt (greater than), lt (less than), gte (greater than or equals), lte (less than or equals), ne (not equals).
+        style: deepObject
+        explode: true
+        schema:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties:
+              type: string
     responses:
       '200':
         description: A list of messages in a tree

--- a/ignite-gpt-openapi/schemas.yaml
+++ b/ignite-gpt-openapi/schemas.yaml
@@ -106,9 +106,12 @@ UpdateTreeRequest:
     data:
       type: object
       required:
+        - id
         - type
         - attributes
       properties:
+        id:
+          type: string
         type:
           type: string
           enum: [tree]
@@ -206,9 +209,12 @@ UpdateMessageRequest:
     data:
       type: object
       required:
+        - id
         - type
         - attributes
       properties:
+        id:
+          type: string
         type:
           type: string
           enum: [message]


### PR DESCRIPTION
updates openapi spec for better jsonapi compliance
- adds `id` to patch request objects
- updates query params for collections (`page`, `sort`, `filter`)