### PR TITLE
ids and references to ids should be uuid format

### DIFF
--- a/ignite-gpt-app/store/igniteApi.ts
+++ b/ignite-gpt-app/store/igniteApi.ts
@@ -5,12 +5,9 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({
         url: `/trees`,
         params: {
-          owner: queryArg.owner,
-          forks: queryArg.forks,
-          createdAt: queryArg.createdAt,
-          updatedAt: queryArg.updatedAt,
           page: queryArg.page,
-          pageSize: queryArg.pageSize,
+          sort: queryArg.sort,
+          filter: queryArg.filter,
         },
       }),
     }),
@@ -44,12 +41,9 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({
         url: `/trees/${queryArg.treeId}/messages`,
         params: {
-          parent: queryArg.parent,
-          role: queryArg.role,
-          createdAt: queryArg.createdAt,
-          updatedAt: queryArg.updatedAt,
           page: queryArg.page,
-          pageSize: queryArg.pageSize,
+          sort: queryArg.sort,
+          filter: queryArg.filter,
         },
       }),
     }),
@@ -89,12 +83,18 @@ export { injectedRtkApi as enhancedApi }
 export type GetTreesApiResponse =
   /** status 200 A list of trees */ TreesResponse
 export type GetTreesApiArg = {
-  owner?: string
-  forks?: number
-  createdAt?: string
-  updatedAt?: string
-  page?: number
-  pageSize?: number
+  page?: {
+    number?: number
+    size?: number
+  }
+  /** Comma-separated field names to sort by. Use -<fieldname> for descending order. */
+  sort?: string
+  /** Field to filter by, in the format filter[<fieldname>][<operator>]=<value>. Operators can be eq (equals), gt (greater than), lt (less than), gte (greater than or equals), lte (less than or equals), ne (not equals). */
+  filter?: {
+    [key: string]: {
+      [key: string]: string
+    }
+  }
 }
 export type CreateTreeApiResponse =
   /** status 201 A created tree */ TreeResponse
@@ -120,12 +120,18 @@ export type GetTreeMessagesApiResponse =
   /** status 200 A list of messages in a tree */ MessagesResponse
 export type GetTreeMessagesApiArg = {
   treeId: string
-  parent?: string
-  role?: string
-  createdAt?: string
-  updatedAt?: string
-  page?: number
-  pageSize?: number
+  page?: {
+    number?: number
+    size?: number
+  }
+  /** Comma-separated field names to sort by. Use -<fieldname> for descending order. */
+  sort?: string
+  /** Field to filter by, in the format filter[<fieldname>][<operator>]=<value>. Operators can be eq (equals), gt (greater than), lt (less than), gte (greater than or equals), lte (less than or equals), ne (not equals). */
+  filter?: {
+    [key: string]: {
+      [key: string]: string
+    }
+  }
 }
 export type CreateTreeMessageApiResponse =
   /** status 201 A created message */ MessageResponse
@@ -216,6 +222,7 @@ export type UpdateTreeAttributes = {
 }
 export type UpdateTreeRequest = {
   data: {
+    id: string
     type: 'tree'
     attributes: UpdateTreeAttributes
   }
@@ -260,6 +267,7 @@ export type UpdateMessageAttributes = {
 }
 export type UpdateMessageRequest = {
   data: {
+    id: string
     type: 'message'
     attributes: UpdateMessageAttributes
   }

--- a/ignite-gpt-openapi/paths.yaml
+++ b/ignite-gpt-openapi/paths.yaml
@@ -79,6 +79,7 @@
         required: true
         schema:
           type: string
+          format: uuid
     responses:
       '200':
         description: A tree
@@ -101,6 +102,7 @@
         required: true
         schema:
           type: string
+          format: uuid
     requestBody:
       content:
         application/json:
@@ -128,6 +130,7 @@
         required: true
         schema:
           type: string
+          format: uuid
     responses:
       '204':
         description: Tree successfully deleted
@@ -147,6 +150,7 @@
         required: true
         schema:
           type: string
+          format: uuid
       - name: page[number]
         in: query
         description: Page number for pagination
@@ -195,6 +199,7 @@
         required: true
         schema:
           type: string
+          format: uuid
     requestBody:
       content:
         application/json:
@@ -228,11 +233,13 @@
         required: true
         schema:
           type: string
+          format: uuid
       - name: msgId
         in: path
         required: true
         schema:
           type: string
+          format: uuid
     requestBody:
       content:
         application/json:
@@ -260,11 +267,13 @@
         required: true
         schema:
           type: string
+          format: uuid
       - name: msgId
         in: path
         required: true
         schema:
           type: string
+          format: uuid
     responses:
       '204':
         description: Message successfully deleted

--- a/ignite-gpt-openapi/schemas.yaml
+++ b/ignite-gpt-openapi/schemas.yaml
@@ -3,6 +3,7 @@ TreeResource:
   properties:
     id:
       type: string
+      format: uuid
     type:
       type: string
       enum: [tree]
@@ -25,6 +26,7 @@ TreeAttributes:
       format: date-time
     owner:
       type: string
+      format: uuid
     isPrivate:
       type: boolean
     isDeleted:
@@ -43,6 +45,7 @@ CreateTreeAttributes:
       type: boolean
     fork:
       type: string
+      format: uuid
 UpdateTreeAttributes:
   type: object
   properties:
@@ -93,6 +96,7 @@ CreateTreeRequest:
       properties:
         id:
           type: string
+          format: uuid
         type:
           type: string
           enum: [tree]
@@ -112,6 +116,7 @@ UpdateTreeRequest:
       properties:
         id:
           type: string
+          format: uuid
         type:
           type: string
           enum: [tree]
@@ -122,6 +127,7 @@ MessageResource:
   properties:
     id:
       type: string
+      format: uuid
     type:
       type: string
       enum: [message]
@@ -140,6 +146,7 @@ MessageAttributes:
       type: boolean
     parent:
       type: string
+      format: uuid
     role:
       type: string
     content:
@@ -152,6 +159,7 @@ CreateMessageAttributes:
   properties:
     parent:
       type: string
+      format: uuid
     role:
       type: string
     content:
@@ -161,6 +169,7 @@ UpdateMessageAttributes:
   properties:
     parent:
       type: string
+      format: uuid
     role:
       type: string
     content:
@@ -196,6 +205,7 @@ CreateMessageRequest:
       properties:
         id:
           type: string
+          format: uuid
         type:
           type: string
           enum: [message]
@@ -215,6 +225,7 @@ UpdateMessageRequest:
       properties:
         id:
           type: string
+          format: uuid
         type:
           type: string
           enum: [message]
@@ -227,6 +238,7 @@ Error:
   properties:
     id:
       type: string
+      format: uuid
     links:
       type: object
       properties:


### PR DESCRIPTION
adds `format: uuid` to strings corresponding to id fields or references to id fields (`id`, `treeId`, `msgId`, `owner`, `fork`, `parent`, etc.)